### PR TITLE
对应fis新版.

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,5 +9,5 @@ var _ = require('underscore');
 
 module.exports = function(content, file, conf){
     fis.util.merge(_.templateSettings, conf);
-    return _.template(content).source;
+    return _.template(content.toString()).source;
 };


### PR DESCRIPTION
fis最新代码里面content已经不是string了，而是一个Buffer object， 所以需要调用toString转换为string才能传递给underscore
